### PR TITLE
ci: fix goreleaser for building a library

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,2 @@
+builds:
+  - skip: true


### PR DESCRIPTION
https://goreleaser.com/errors/no-main/#if-you-are-building-a-library

> If you are building a library[¶](https://goreleaser.com/errors/no-main/#if-you-are-building-a-library)
> 
> Add something like this to your config:
> 
> `.goreleaser.yaml`
> ```lml
> builds:
>   - skip: true
>  ```