### PR TITLE
feat: add support for fetching users from App Store Connect

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,9 +1,11 @@
 package appstore
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/oliver-binns/appstore-go/authorization"
+	"github.com/oliver-binns/appstore-go/users"
 	"github.com/oliver-binns/googleplay-go/networking"
 )
 
@@ -32,6 +34,10 @@ func AppStoreClient(
 		client:  &client,
 		baseURL: "https://api.appstoreconnect.apple.com/v1/",
 	}
+}
+
+func (c *Client) GetUser(ctx context.Context, id string) (*users.User, error) {
+	return users.Get(*c.client, ctx, c.baseURL, id)
 }
 
 func check(e error) {

--- a/users/get.go
+++ b/users/get.go
@@ -1,0 +1,52 @@
+package users
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/oliver-binns/googleplay-go/networking"
+)
+
+func Get(c networking.HTTPClient, ctx context.Context, rawURL string, id string) (*User, error) {
+	// Parse the raw URL
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+	parsedURL.Path = path.Join(parsedURL.Path, "users", id)
+
+	// Create the HTTP request
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	userListResponse := new(connectAPIResponse)
+	if err := json.NewDecoder(resp.Body).Decode(userListResponse); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close response body: %w", err)
+	}
+
+	return &userListResponse.Data.Data, nil
+}
+
+type connectAPIResponse struct {
+	Data connectObjectResponse `json:"data"`
+}
+
+type connectObjectResponse struct {
+	ID   string `json:"id"`
+	Data User   `json:"attributes"`
+}

--- a/users/get_test.go
+++ b/users/get_test.go
@@ -1,0 +1,94 @@
+package users
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListUsers_MakesRequest(t *testing.T) {
+	httpClient := &mockHTTPClient{
+		response: `{
+			"users": [
+			
+			],
+			"nextPageToken": string
+		}`,
+	}
+
+	_, _ = Get(
+		httpClient, context.Background(), "https://example.com", "abcd1234-5678-90ab-cdef-1234567890ab",
+	)
+
+	assert.Equal(t, len(httpClient.requests), 1)
+	assert.Equal(t, httpClient.requests[0].Method, "GET")
+	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com/users/abcd1234-5678-90ab-cdef-1234567890ab")
+}
+
+func TestListUsers_DecodesResponse(t *testing.T) {
+	httpClient := &mockHTTPClient{
+		response: `{
+  "data" : {
+    "type" : "users",
+    "id" : "69a495c9-7dbc-5733-e053-5b8c7c1155b0",
+    "attributes" : {
+      "allAppsVisible" : true,
+      "lastName" : "Binns",
+      "firstName" : "Oliver",
+      "provisioningAllowed" : true,
+      "roles" : [ "ACCOUNT_HOLDER", "ADMIN" ],
+      "username" : "mail@oliverbinns.co.uk"
+    },
+    "relationships" : {
+      "visibleApps" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/users/69a495c9-7dbc-5733-e053-5b8c7c1155b0/relationships/visibleApps",
+          "related" : "https://api.appstoreconnect.apple.com/v1/users/69a495c9-7dbc-5733-e053-5b8c7c1155b0/visibleApps"
+        }
+      }
+    },
+    "links" : {
+      "self" : "https://api.appstoreconnect.apple.com/v1/users/69a495c9-7dbc-5733-e053-5b8c7c1155b0"
+    }
+  },
+  "links" : {
+    "self" : "https://api.appstoreconnect.apple.com/v1/users/69a495c9-7dbc-5733-e053-5b8c7c1155b0"
+  }
+}`,
+	}
+
+	user, _ := Get(
+		httpClient, context.Background(), "https://example.com", "abc",
+	)
+
+	assert.Equal(t, user.FirstName, "Oliver")
+	assert.Equal(t, user.LastName, "Binns")
+	assert.Equal(t, user.Username, "mail@oliverbinns.co.uk")
+}
+
+type mockHTTPClient struct {
+	requests []*http.Request
+	response string
+
+	statusCode *int
+}
+
+func (c *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.requests = append(c.requests, req)
+
+	responseBody := io.NopCloser(bytes.NewReader([]byte(c.response)))
+
+	status := http.StatusOK
+	if c.statusCode != nil {
+		status = *c.statusCode
+	}
+
+	return &http.Response{
+		StatusCode: status,
+		Body:       responseBody,
+	}, nil
+}

--- a/users/user.go
+++ b/users/user.go
@@ -1,0 +1,10 @@
+package users
+
+type User struct {
+	FirstName           string     `json:"firstName"`
+	LastName            string     `json:"lastName"`
+	Username            string     `json:"username"`
+	Roles               []UserRole `json:"roles"`
+	AllAppsVisible      bool       `json:"allAppsVisible,omitempty"`
+	ProvisioningAllowed bool       `json:"provisioningAllowed,omitempty"`
+}

--- a/users/user_role.go
+++ b/users/user_role.go
@@ -1,0 +1,19 @@
+package users
+
+type UserRole string
+
+const (
+	Admin                       UserRole = "ADMIN"
+	Finance                     UserRole = "FINANCE"
+	AccountHolder               UserRole = "ACCOUNT_HOLDER"
+	Sales                       UserRole = "SALES"
+	Marketing                   UserRole = "MARKETING"
+	AppManager                  UserRole = "APP_MANAGER"
+	Developer                   UserRole = "DEVELOPER"
+	AccessToReports             UserRole = "ACCESS_TO_REPORTS"
+	CustomerSupport             UserRole = "CUSTOMER_SUPPORT"
+	CreateApps                  UserRole = "CREATE_APPS"
+	CloudManagedDeveloperID     UserRole = "CLOUD_MANAGED_DEVELOPER_ID"
+	CloudManagedAppDistribution UserRole = "CLOUD_MANAGED_APP_DISTRIBUTION"
+	GenerateIndividualKeys      UserRole = "GENERATE_INDIVIDUAL_KEYS"
+)


### PR DESCRIPTION
Add support for fetching users from App Store Connect API.

<img width="955" alt="image" src="https://github.com/user-attachments/assets/4e3a5e14-a391-48f7-92bc-402d6acc464d" />

```
oliver@Olivers-MacBook-Air main % go run main.go
User: &{FirstName:Oliver LastName:Binns Username:mail@oliverbinns.co.uk Roles:[ACCOUNT_HOLDER ADMIN] AllAppsVisible:true ProvisioningAllowed:true}
Error: %!s(<nil>)
```