### PR TITLE
feat: add user IDs to returned object

### DIFF
--- a/users/create.go
+++ b/users/create.go
@@ -55,14 +55,6 @@ func Create(c networking.HTTPClient, ctx context.Context, rawURL string, user Us
 		return nil, fmt.Errorf("failed to close response body: %w", err)
 	}
 
+	userResponse.Data.Data.ID = userResponse.Data.ID
 	return &userResponse.Data.Data, nil
-}
-
-type UserInvitation struct {
-	FirstName           string     `json:"firstName"`
-	LastName            string     `json:"lastName"`
-	Email               string     `json:"email"`
-	Roles               []UserRole `json:"roles"`
-	AllAppsVisible      bool       `json:"allAppsVisible,omitempty"`
-	ProvisioningAllowed bool       `json:"provisioningAllowed,omitempty"`
 }

--- a/users/create_test.go
+++ b/users/create_test.go
@@ -57,6 +57,7 @@ func TestCreateUser_DecodesResponse(t *testing.T) {
 		httpClient, context.Background(), "https://example.com", UserInvitation{},
 	)
 
+	assert.Equal(t, user.ID, "69a495c9-7dbc-5733-e053-5b8c7c1155b0")
 	assert.Equal(t, user.FirstName, "Oliver")
 	assert.Equal(t, user.LastName, "Binns")
 	assert.Equal(t, user.Email, "mail@oliverbinns.co.uk")

--- a/users/get.go
+++ b/users/get.go
@@ -40,5 +40,6 @@ func Get(c networking.HTTPClient, ctx context.Context, rawURL string, id string)
 		return nil, fmt.Errorf("failed to close response body: %w", err)
 	}
 
+	userResponse.Data.Data.ID = userResponse.Data.ID
 	return &userResponse.Data.Data, nil
 }

--- a/users/get_test.go
+++ b/users/get_test.go
@@ -65,6 +65,7 @@ func TestGetUser_DecodesResponse(t *testing.T) {
 		httpClient, context.Background(), "https://example.com", "abc",
 	)
 
+	assert.Equal(t, user.ID, "69a495c9-7dbc-5733-e053-5b8c7c1155b0")
 	assert.Equal(t, user.FirstName, "Oliver")
 	assert.Equal(t, user.LastName, "Binns")
 	assert.Equal(t, user.Username, "mail@oliverbinns.co.uk")

--- a/users/invitation.go
+++ b/users/invitation.go
@@ -1,10 +1,10 @@
 package users
 
-type User struct {
+type UserInvitation struct {
 	ID                  string     `json:"id,omitempty"`
 	FirstName           string     `json:"firstName"`
 	LastName            string     `json:"lastName"`
-	Username            string     `json:"username"`
+	Email               string     `json:"email"`
 	Roles               []UserRole `json:"roles"`
 	AllAppsVisible      bool       `json:"allAppsVisible,omitempty"`
 	ProvisioningAllowed bool       `json:"provisioningAllowed,omitempty"`


### PR DESCRIPTION
User IDs are now returned from both create and get API requests.

```bash
oliver@Olivers-MacBook-Air main % go run main.go
User: &{ID:69a495c9-7dbc-5733-e053-5b8c7c1155b0 FirstName:Oliver LastName:Binns Username:mail@oliverbinns.co.uk Roles:[ACCOUNT_HOLDER ADMIN] AllAppsVisible:true ProvisioningAllowed:true}
Error: %!s(<nil>)
User: &{ID:111e38f7-6cd3-4fb1-a230-68b0d8673a32 FirstName:Joe LastName:Bloggs Username:test@oliverbinns.co.uk Roles:[MARKETING] AllAppsVisible:false ProvisioningAllowed:false}
Error: %!s(<nil>)
```