### PR TITLE
feat: fetch user falls back to userInvitations incase user has not accepted their invite yet

### DIFF
--- a/client.go
+++ b/client.go
@@ -40,7 +40,7 @@ func (c *Client) GetUser(ctx context.Context, id string) (*users.User, error) {
 	return users.Get(*c.client, ctx, c.baseURL, id)
 }
 
-func (c *Client) CreateUser(ctx context.Context, user users.UserInvitation) (*users.UserInvitation, error) {
+func (c *Client) CreateUser(ctx context.Context, user users.User) (*users.User, error) {
 	return users.Create(*c.client, ctx, c.baseURL, user)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require github.com/golang-jwt/jwt/v5 v5.2.2
 
 require github.com/stretchr/testify v1.10.0
 
-require github.com/oliver-binns/googleplay-go v0.0.0-20250505070929-9813eeeed337
+require github.com/oliver-binns/googleplay-go v0.0.0-20250628102308-9551b2040f75
 
 require github.com/davecgh/go-spew v1.1.1 // indirect
 

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeD
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/oliver-binns/googleplay-go v0.0.0-20250505070929-9813eeeed337 h1:2uauErCpCdYzZGyZ473teaB5DMXJjRxN+p5SNdRHfIk=
 github.com/oliver-binns/googleplay-go v0.0.0-20250505070929-9813eeeed337/go.mod h1:JUBt/rWkAOkR9qSxKVH4Iid37RrExqIQheP5MVXLy/Y=
+github.com/oliver-binns/googleplay-go v0.0.0-20250628102308-9551b2040f75 h1:VA4I9YBHeXFvwrrayDnGizSR26KoUmZw4rbUveyNq2k=
+github.com/oliver-binns/googleplay-go v0.0.0-20250628102308-9551b2040f75/go.mod h1:JUBt/rWkAOkR9qSxKVH4Iid37RrExqIQheP5MVXLy/Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/mocknetworking/MockHTTPClient.go
+++ b/mocknetworking/MockHTTPClient.go
@@ -1,0 +1,35 @@
+package mocknetworking
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+)
+
+type MockHTTPClient struct {
+	Requests  []*http.Request
+	Responses []MockHTTPResponse
+}
+
+type MockHTTPResponse struct {
+	StatusCode *int
+	Body       string
+}
+
+func (c *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.Requests = append(c.Requests, req)
+	response := c.Responses[0]
+	c.Responses = c.Responses[1:]
+
+	responseBody := io.NopCloser(bytes.NewReader([]byte(response.Body)))
+
+	status := http.StatusOK
+	if response.StatusCode != nil {
+		status = *response.StatusCode
+	}
+
+	return &http.Response{
+		StatusCode: status,
+		Body:       responseBody,
+	}, nil
+}

--- a/mocknetworking/SuccessClient.go
+++ b/mocknetworking/SuccessClient.go
@@ -1,0 +1,22 @@
+package mocknetworking
+
+func MockHTTPClientWith200Response(body string) *MockHTTPClient {
+	return &MockHTTPClient{
+		Responses: []MockHTTPResponse{
+			{
+				Body: body,
+			},
+		},
+	}
+}
+
+func MockHTTPClientWithSingleResponse(statusCode int, body string) *MockHTTPClient {
+	return &MockHTTPClient{
+		Responses: []MockHTTPResponse{
+			{
+				StatusCode: &statusCode,
+				Body:       body,
+			},
+		},
+	}
+}

--- a/users/create_test.go
+++ b/users/create_test.go
@@ -5,30 +5,29 @@ import (
 	"io"
 	"testing"
 
+	"github.com/oliver-binns/appstore-go/mocknetworking"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateUser_MakesRequest(t *testing.T) {
-	user := UserInvitation{
+	user := User{
 		FirstName: "Joseph",
 		LastName:  "Bloggs",
-		Email:     "joe.bloggs@example.com",
+		Username:  "joe.bloggs@example.com",
 		Roles:     []UserRole{Marketing},
 	}
-	httpClient := &mockHTTPClient{
-		response: ``,
-	}
+	httpClient := mocknetworking.MockHTTPClientWith200Response(`{ }`)
 
 	_, _ = Create(
 		httpClient, context.Background(), "https://example.com", user,
 	)
 
-	assert.Equal(t, len(httpClient.requests), 1)
-	assert.Equal(t, httpClient.requests[0].Method, "POST")
-	assert.Equal(t, httpClient.requests[0].Header.Get("Content-Type"), "application/json")
-	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com/userInvitations")
+	assert.Equal(t, len(httpClient.Requests), 1)
+	assert.Equal(t, httpClient.Requests[0].Method, "POST")
+	assert.Equal(t, httpClient.Requests[0].Header.Get("Content-Type"), "application/json")
+	assert.Equal(t, httpClient.Requests[0].URL.String(), "https://example.com/userInvitations")
 
-	bodyBytes, err := io.ReadAll(httpClient.requests[0].Body)
+	bodyBytes, err := io.ReadAll(httpClient.Requests[0].Body)
 	assert.NoError(t, err)
 	bodyString := string(bodyBytes)
 	assert.Equal(t, `{"data":{"type":"userInvitations","attributes":{"firstName":"Joseph","lastName":"Bloggs","email":"joe.bloggs@example.com","roles":["MARKETING"]}}}
@@ -36,29 +35,28 @@ func TestCreateUser_MakesRequest(t *testing.T) {
 }
 
 func TestCreateUser_DecodesResponse(t *testing.T) {
-	httpClient := &mockHTTPClient{
-		response: `{
-			"data": {
-				"type": "users",
-				"id": "69a495c9-7dbc-5733-e053-5b8c7c1155b0",
-				"attributes": {
-					"allAppsVisible": true,
-					"lastName": "Binns",
-					"firstName": "Oliver",
-					"provisioningAllowed": true,
-					"roles": ["ACCOUNT_HOLDER", "ADMIN"],
-					"email": "mail@oliverbinns.co.uk"
-				}
+	httpClient := mocknetworking.MockHTTPClientWith200Response(`
+	{
+		"data": {
+			"type": "users",
+			"id": "69a495c9-7dbc-5733-e053-5b8c7c1155b0",
+			"attributes": {
+				"allAppsVisible": true,
+				"lastName": "Binns",
+				"firstName": "Oliver",
+				"provisioningAllowed": true,
+				"roles": ["ACCOUNT_HOLDER", "ADMIN"],
+				"email": "mail@oliverbinns.co.uk"
 			}
-		}`,
-	}
+		}
+	}`)
 
 	user, _ := Create(
-		httpClient, context.Background(), "https://example.com", UserInvitation{},
+		httpClient, context.Background(), "https://example.com", User{},
 	)
 
 	assert.Equal(t, user.ID, "69a495c9-7dbc-5733-e053-5b8c7c1155b0")
 	assert.Equal(t, user.FirstName, "Oliver")
 	assert.Equal(t, user.LastName, "Binns")
-	assert.Equal(t, user.Email, "mail@oliverbinns.co.uk")
+	assert.Equal(t, user.Username, "mail@oliverbinns.co.uk")
 }

--- a/users/get.go
+++ b/users/get.go
@@ -27,6 +27,12 @@ func Get(c networking.HTTPClient, ctx context.Context, rawURL string, id string)
 	}
 
 	resp, err := c.Do(req)
+
+	// If the user is not found, see if the user invitation exists
+	if resp.StatusCode == http.StatusNotFound {
+		return getInvitations(c, ctx, rawURL, id)
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -42,4 +48,37 @@ func Get(c networking.HTTPClient, ctx context.Context, rawURL string, id string)
 
 	userResponse.Data.Data.ID = userResponse.Data.ID
 	return &userResponse.Data.Data, nil
+}
+
+func getInvitations(c networking.HTTPClient, ctx context.Context, rawURL string, id string) (*User, error) {
+	parsedURL, _ := url.Parse(rawURL)
+	parsedURL.Path = path.Join(parsedURL.Path, "userInvitations", id)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	resp, err := c.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	userResponse := new(connectapi.Response[userInvitation])
+	if err := json.NewDecoder(resp.Body).Decode(userResponse); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close response body: %w", err)
+	}
+
+	return &User{
+		ID:                  userResponse.Data.ID,
+		FirstName:           userResponse.Data.Data.FirstName,
+		LastName:            userResponse.Data.Data.LastName,
+		Username:            userResponse.Data.Data.Email,
+		Roles:               userResponse.Data.Data.Roles,
+		AllAppsVisible:      userResponse.Data.Data.AllAppsVisible,
+		ProvisioningAllowed: userResponse.Data.Data.ProvisioningAllowed,
+	}, nil
 }

--- a/users/get_test.go
+++ b/users/get_test.go
@@ -1,37 +1,55 @@
 package users
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"net/http"
 	"testing"
 
+	"github.com/oliver-binns/appstore-go/mocknetworking"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetUser_MakesRequest(t *testing.T) {
-	httpClient := &mockHTTPClient{
-		response: `{
-			"users": [
-			
-			],
-			"nextPageToken": string
-		}`,
-	}
+	httpClient := mocknetworking.MockHTTPClientWith200Response(`{ }`)
 
 	_, _ = Get(
 		httpClient, context.Background(), "https://example.com", "abcd1234-5678-90ab-cdef-1234567890ab",
 	)
 
-	assert.Equal(t, len(httpClient.requests), 1)
-	assert.Equal(t, httpClient.requests[0].Method, "GET")
-	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com/users/abcd1234-5678-90ab-cdef-1234567890ab")
+	assert.Equal(t, len(httpClient.Requests), 1)
+	assert.Equal(t, httpClient.Requests[0].Method, "GET")
+	assert.Equal(t, httpClient.Requests[0].URL.String(), "https://example.com/users/abcd1234-5678-90ab-cdef-1234567890ab")
+}
+
+func TestGetUser_MakesSecondRequestToInvitations_When404Returned(t *testing.T) {
+	notFound := http.StatusNotFound
+
+	httpClient := mocknetworking.MockHTTPClient{
+		Responses: []mocknetworking.MockHTTPResponse{
+			{
+				StatusCode: &notFound,
+				Body:       `{ }`,
+			},
+			{
+				Body: `{ }`,
+			},
+		},
+	}
+
+	_, _ = Get(
+		&httpClient, context.Background(), "https://example.com", "abcd1234-5678-90ab-cdef-1234567890ab",
+	)
+
+	assert.Equal(t, len(httpClient.Requests), 2)
+	assert.Equal(t, httpClient.Requests[0].Method, "GET")
+	assert.Equal(t, httpClient.Requests[0].URL.String(), "https://example.com/users/abcd1234-5678-90ab-cdef-1234567890ab")
+
+	assert.Equal(t, httpClient.Requests[1].Method, "GET")
+	assert.Equal(t, httpClient.Requests[1].URL.String(), "https://example.com/userInvitations/abcd1234-5678-90ab-cdef-1234567890ab")
 }
 
 func TestGetUser_DecodesResponse(t *testing.T) {
-	httpClient := &mockHTTPClient{
-		response: `{
+	httpClient := mocknetworking.MockHTTPClientWith200Response(`{
   "data" : {
     "type" : "users",
     "id" : "69a495c9-7dbc-5733-e053-5b8c7c1155b0",
@@ -59,11 +77,13 @@ func TestGetUser_DecodesResponse(t *testing.T) {
     "self" : "https://api.appstoreconnect.apple.com/v1/users/69a495c9-7dbc-5733-e053-5b8c7c1155b0"
   }
 }`,
-	}
+	)
 
-	user, _ := Get(
+	user, err := Get(
 		httpClient, context.Background(), "https://example.com", "abc",
 	)
+
+	assert.Nil(t, err)
 
 	assert.Equal(t, user.ID, "69a495c9-7dbc-5733-e053-5b8c7c1155b0")
 	assert.Equal(t, user.FirstName, "Oliver")
@@ -71,25 +91,43 @@ func TestGetUser_DecodesResponse(t *testing.T) {
 	assert.Equal(t, user.Username, "mail@oliverbinns.co.uk")
 }
 
-type mockHTTPClient struct {
-	requests []*http.Request
-	response string
+func TestGetUser_DecodesInvitationResponse_When404ReturnedFromUsers(t *testing.T) {
+	notFound := http.StatusNotFound
 
-	statusCode *int
-}
-
-func (c *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	c.requests = append(c.requests, req)
-
-	responseBody := io.NopCloser(bytes.NewReader([]byte(c.response)))
-
-	status := http.StatusOK
-	if c.statusCode != nil {
-		status = *c.statusCode
+	httpClient := mocknetworking.MockHTTPClient{
+		Responses: []mocknetworking.MockHTTPResponse{
+			{
+				StatusCode: &notFound,
+				Body:       `{ }`,
+			},
+			{
+				Body: `
+				{
+					"data": {
+						"type": "users",
+						"id": "69a495c9-7dbc-5733-e053-5b8c7c1155b0",
+						"attributes": {
+							"allAppsVisible": true,
+							"lastName": "Binns",
+							"firstName": "Oliver",
+							"provisioningAllowed": true,
+							"roles": ["ACCOUNT_HOLDER", "ADMIN"],
+							"email": "mail@oliverbinns.co.uk"
+						}
+					}
+				}`,
+			},
+		},
 	}
 
-	return &http.Response{
-		StatusCode: status,
-		Body:       responseBody,
-	}, nil
+	user, err := Get(
+		&httpClient, context.Background(), "https://example.com", "abcd1234-5678-90ab-cdef-1234567890ab",
+	)
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, user.ID, "69a495c9-7dbc-5733-e053-5b8c7c1155b0")
+	assert.Equal(t, user.FirstName, "Oliver")
+	assert.Equal(t, user.LastName, "Binns")
+	assert.Equal(t, user.Username, "mail@oliverbinns.co.uk")
 }

--- a/users/invitation.go
+++ b/users/invitation.go
@@ -1,6 +1,6 @@
 package users
 
-type UserInvitation struct {
+type userInvitation struct {
 	ID                  string     `json:"id,omitempty"`
 	FirstName           string     `json:"firstName"`
 	LastName            string     `json:"lastName"`


### PR DESCRIPTION
If user has not accepted their invite to App Store Connect, the API will return a 404 from the `/users` endpoint.
In this case, we should fallback to the `/userInvitations` endpoint to see if a pending request is still present.

This pull request also introduces a new `mocknetworking` module which encapsulates mock classes for used for testing purposes.