### PR TITLE
feat: add ability to delete users

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,6 +44,10 @@ func (c *Client) CreateUser(ctx context.Context, user users.User) (*users.User, 
 	return users.Create(*c.client, ctx, c.baseURL, user)
 }
 
+func (c *Client) DeleteUser(ctx context.Context, id string) error {
+	return users.Delete(*c.client, ctx, c.baseURL, id)
+}
+
 func check(e error) {
 	if e != nil {
 		panic(e)

--- a/users/delete.go
+++ b/users/delete.go
@@ -1,0 +1,36 @@
+package users
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/oliver-binns/googleplay-go/networking"
+)
+
+func Delete(c networking.HTTPClient, ctx context.Context, rawURL string, id string) error {
+	// Parse the raw URL
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse URL: %w", err)
+	}
+	parsedURL.Path = path.Join(parsedURL.Path, "users", id)
+
+	// Create the HTTP request
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, parsedURL.String(), http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.Do(req)
+
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to delete user: %w", err)
+	} else {
+		return fmt.Errorf("unexpected response code: %d", resp.StatusCode)
+	}
+}

--- a/users/delete_test.go
+++ b/users/delete_test.go
@@ -1,0 +1,48 @@
+package users
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/oliver-binns/appstore-go/mocknetworking"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteUser_MakesRequest(t *testing.T) {
+	httpClient := mocknetworking.MockHTTPClientWith200Response(`{ }`)
+
+	_ = Delete(
+		httpClient, context.Background(), "https://example.com", "user-id",
+	)
+
+	assert.Equal(t, len(httpClient.Requests), 1)
+	assert.Equal(t, httpClient.Requests[0].Method, "DELETE")
+	assert.Equal(t, httpClient.Requests[0].URL.String(), "https://example.com/users/user-id")
+
+	// The body should be empty for a DELETE request
+	bodyBytes, err := io.ReadAll(httpClient.Requests[0].Body)
+	assert.NoError(t, err)
+	assert.Equal(t, len(bodyBytes), 0)
+}
+
+func TestDeleteUser_ReturnsNilForSuccess(t *testing.T) {
+	httpClient := mocknetworking.MockHTTPClientWithSingleResponse(http.StatusNoContent, `{ }`)
+
+	err := Delete(
+		httpClient, context.Background(), "https://example.com", "user-id",
+	)
+
+	assert.NoError(t, err)
+}
+
+func TestDeleteUser_ThrowsErrorForUnexpectedStatusCode(t *testing.T) {
+	httpClient := mocknetworking.MockHTTPClientWith200Response(`{ }`)
+
+	err := Delete(
+		httpClient, context.Background(), "https://example.com", "user-id",
+	)
+
+	assert.Equal(t, err.Error(), "unexpected response code: 200")
+}


### PR DESCRIPTION
Users can now be deleted with by calling `client.DeleteUser`:

```go
err = client.DeleteUser(context.Background(), "a8e50ba8-8c30-4e26-8a17-67ae4d8e6f22")
fmt.Printf("Error: %s\n", err)
```