### PR TITLE
feat: cancel user invitations if user is deleted

### DIFF
--- a/users/delete.go
+++ b/users/delete.go
@@ -28,6 +28,34 @@ func Delete(c networking.HTTPClient, ctx context.Context, rawURL string, id stri
 
 	if resp.StatusCode == http.StatusNoContent {
 		return nil
+	} else if resp.StatusCode == http.StatusNotFound {
+		// if the user is not found, it might be an unaccepted user invitation:
+		return revokeInvitation(c, ctx, rawURL, id)
+	} else if err != nil {
+		return fmt.Errorf("failed to delete user: %w", err)
+	} else {
+		return fmt.Errorf("unexpected response code: %d", resp.StatusCode)
+	}
+}
+
+func revokeInvitation(c networking.HTTPClient, ctx context.Context, rawURL string, id string) error {
+	// Parse the raw URL
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse URL: %w", err)
+	}
+	parsedURL.Path = path.Join(parsedURL.Path, "userInvitations", id)
+
+	// Create the HTTP request
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, parsedURL.String(), http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.Do(req)
+
+	if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusNotFound {
+		return nil
 	} else if err != nil {
 		return fmt.Errorf("failed to delete user: %w", err)
 	} else {

--- a/users/delete_test.go
+++ b/users/delete_test.go
@@ -46,3 +46,103 @@ func TestDeleteUser_ThrowsErrorForUnexpectedStatusCode(t *testing.T) {
 
 	assert.Equal(t, err.Error(), "unexpected response code: 200")
 }
+
+func TestDeleteUser_MakesSecondRequest_IfUserNotFound(t *testing.T) {
+	notFound := http.StatusNotFound
+	httpClient := mocknetworking.MockHTTPClient{
+		Responses: []mocknetworking.MockHTTPResponse{
+			{
+				StatusCode: &notFound,
+				Body:       `{ }`,
+			},
+			{
+				Body: `{ }`,
+			},
+		},
+	}
+
+	_ = Delete(
+		&httpClient, context.Background(), "https://example.com", "user-id",
+	)
+
+	assert.Equal(t, len(httpClient.Requests), 2)
+	assert.Equal(t, httpClient.Requests[0].Method, "DELETE")
+	assert.Equal(t, httpClient.Requests[0].URL.String(), "https://example.com/users/user-id")
+
+	assert.Equal(t, httpClient.Requests[1].Method, "DELETE")
+	assert.Equal(t, httpClient.Requests[1].URL.String(), "https://example.com/userInvitations/user-id")
+	// The body should be empty for a DELETE request
+	bodyBytes, err := io.ReadAll(httpClient.Requests[1].Body)
+	assert.NoError(t, err)
+	assert.Equal(t, len(bodyBytes), 0)
+}
+
+func TestDeleteUser_RevokeInvitationRequest_ReturnsNilForSuccess(t *testing.T) {
+	notFound := http.StatusNotFound
+	noContent := http.StatusNoContent
+	httpClient := mocknetworking.MockHTTPClient{
+		Responses: []mocknetworking.MockHTTPResponse{
+			{
+				StatusCode: &notFound,
+				Body:       `{ }`,
+			},
+			{
+				StatusCode: &noContent,
+				Body:       `{ }`,
+			},
+		},
+	}
+
+	err := Delete(
+		&httpClient, context.Background(), "https://example.com", "user-id",
+	)
+
+	assert.NoError(t, err)
+}
+
+func TestDeleteUser_RevokeInvitationRequest_ThrowsErrorForUnexpectedStatusCode(t *testing.T) {
+	notFound := http.StatusNotFound
+	conflict := http.StatusConflict
+	httpClient := mocknetworking.MockHTTPClient{
+		Responses: []mocknetworking.MockHTTPResponse{
+			{
+				StatusCode: &notFound,
+				Body:       `{ }`,
+			},
+			{
+				StatusCode: &conflict,
+				Body:       `{ }`,
+			},
+		},
+	}
+
+	err := Delete(
+		&httpClient, context.Background(), "https://example.com", "user-id",
+	)
+
+	assert.Equal(t, err.Error(), "unexpected response code: 409")
+}
+
+// If the user is not found, it's likely that the user invitation has expired.
+// This is not considered an error, so we return nil.
+func TestDeleteUser_RevokeInvitationRequest_ReturnsNilForNotFound(t *testing.T) {
+	notFound := http.StatusNotFound
+	httpClient := mocknetworking.MockHTTPClient{
+		Responses: []mocknetworking.MockHTTPResponse{
+			{
+				StatusCode: &notFound,
+				Body:       `{ }`,
+			},
+			{
+				StatusCode: &notFound,
+				Body:       `{ }`,
+			},
+		},
+	}
+
+	err := Delete(
+		&httpClient, context.Background(), "https://example.com", "user-id",
+	)
+
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
User invitations are now also cancelled when `DeleteUser` is called.