### PR TITLE
feat: expose information on whether user has accepted the invite or not

### DIFF
--- a/users/get.go
+++ b/users/get.go
@@ -47,6 +47,7 @@ func Get(c networking.HTTPClient, ctx context.Context, rawURL string, id string)
 	}
 
 	userResponse.Data.Data.ID = userResponse.Data.ID
+	userResponse.Data.Data.HasAcceptedInvite = true
 	return &userResponse.Data.Data, nil
 }
 
@@ -80,5 +81,6 @@ func getInvitations(c networking.HTTPClient, ctx context.Context, rawURL string,
 		Roles:               userResponse.Data.Data.Roles,
 		AllAppsVisible:      userResponse.Data.Data.AllAppsVisible,
 		ProvisioningAllowed: userResponse.Data.Data.ProvisioningAllowed,
+		HasAcceptedInvite:   false,
 	}, nil
 }

--- a/users/get_test.go
+++ b/users/get_test.go
@@ -85,6 +85,8 @@ func TestGetUser_DecodesResponse(t *testing.T) {
 
 	assert.Nil(t, err)
 
+	assert.True(t, user.HasAcceptedInvite)
+
 	assert.Equal(t, user.ID, "69a495c9-7dbc-5733-e053-5b8c7c1155b0")
 	assert.Equal(t, user.FirstName, "Oliver")
 	assert.Equal(t, user.LastName, "Binns")
@@ -125,6 +127,8 @@ func TestGetUser_DecodesInvitationResponse_When404ReturnedFromUsers(t *testing.T
 	)
 
 	assert.Nil(t, err)
+
+	assert.False(t, user.HasAcceptedInvite)
 
 	assert.Equal(t, user.ID, "69a495c9-7dbc-5733-e053-5b8c7c1155b0")
 	assert.Equal(t, user.FirstName, "Oliver")

--- a/users/user.go
+++ b/users/user.go
@@ -8,4 +8,5 @@ type User struct {
 	Roles               []UserRole `json:"roles,omitempty"`
 	AllAppsVisible      bool       `json:"allAppsVisible,omitempty"`
 	ProvisioningAllowed bool       `json:"provisioningAllowed,omitempty"`
+	HasAcceptedInvite   bool       `json:"userHasAcceptedInvitation,omitempty"`
 }


### PR DESCRIPTION
`HasAcceptedInvite` returns true if user has accepted the email invite and successfully added as a new user.