### PR TITLE
refactor: copy networking package from archived googleplay-go library

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/oliver-binns/appstore-go/authorization"
+	"github.com/oliver-binns/appstore-go/networking"
 	"github.com/oliver-binns/appstore-go/users"
-	"github.com/oliver-binns/googleplay-go/networking"
 )
 
 type Client struct {

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ require github.com/golang-jwt/jwt/v5 v5.3.1
 
 require github.com/stretchr/testify v1.11.1
 
-require github.com/oliver-binns/googleplay-go v0.0.0-20250628102308-9551b2040f75
-
 require github.com/davecgh/go-spew v1.1.1 // indirect
 
 require github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
-github.com/oliver-binns/googleplay-go v0.0.0-20250628102308-9551b2040f75 h1:VA4I9YBHeXFvwrrayDnGizSR26KoUmZw4rbUveyNq2k=
-github.com/oliver-binns/googleplay-go v0.0.0-20250628102308-9551b2040f75/go.mod h1:JUBt/rWkAOkR9qSxKVH4Iid37RrExqIQheP5MVXLy/Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/networking/http_client.go
+++ b/networking/http_client.go
@@ -1,0 +1,42 @@
+package networking
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type TokenSource interface {
+	Token() (string, error)
+}
+
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type authorizedClient struct {
+	httpClient  HTTPClient
+	tokenSource TokenSource
+}
+
+func NewAuthorizedClient(httpClient HTTPClient, tokenSource TokenSource) HTTPClient {
+	return &authorizedClient{
+		httpClient:  httpClient,
+		tokenSource: tokenSource,
+	}
+}
+
+func (c *authorizedClient) Do(req *http.Request) (*http.Response, error) {
+	token, err := c.tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get token: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+
+	return resp, nil
+}

--- a/networking/http_client_test.go
+++ b/networking/http_client_test.go
@@ -1,0 +1,57 @@
+package networking
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAuthorizedClient_AuthorizationHeaderIsSet(t *testing.T) {
+	httpClient := &mockHTTPClient{
+		statusCode: http.StatusOK,
+	}
+	tokenSource := &mockTokenSource{}
+
+	authorizedClient := NewAuthorizedClient(httpClient, tokenSource)
+	req, _ := http.NewRequest("GET", "https://example.com", nil)
+	_, err := authorizedClient.Do(req)
+
+	assert.Nil(t, err, "Unexpected error: %v", err)
+	assert.Equal(
+		t, "Bearer test-token", req.Header.Get("Authorization"),
+		"Authorization header not set correctly",
+	)
+}
+
+func TestNewAuthorizedClient_Allows2XXStatusCodes(t *testing.T) {
+	httpClient := &mockHTTPClient{
+		statusCode: http.StatusNoContent,
+	}
+	tokenSource := &mockTokenSource{}
+
+	authorizedClient := NewAuthorizedClient(httpClient, tokenSource)
+	req, _ := http.NewRequest("GET", "https://example.com", nil)
+	_, err := authorizedClient.Do(req)
+
+	assert.NoError(t, err)
+}
+
+type mockTokenSource struct{}
+
+func (c *mockTokenSource) Token() (string, error) {
+	return "test-token", nil
+}
+
+type mockHTTPClient struct {
+	statusCode int
+	requests   []*http.Request
+}
+
+func (c *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.requests = append(c.requests, req)
+
+	return &http.Response{
+		StatusCode: c.statusCode,
+	}, nil
+}

--- a/users/create.go
+++ b/users/create.go
@@ -10,7 +10,7 @@ import (
 	"path"
 
 	"github.com/oliver-binns/appstore-go/connectapi"
-	"github.com/oliver-binns/googleplay-go/networking"
+	"github.com/oliver-binns/appstore-go/networking"
 )
 
 func Create(c networking.HTTPClient, ctx context.Context, rawURL string, user User) (*User, error) {

--- a/users/delete.go
+++ b/users/delete.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/oliver-binns/googleplay-go/networking"
+	"github.com/oliver-binns/appstore-go/networking"
 )
 
 func Delete(c networking.HTTPClient, ctx context.Context, rawURL string, id string) error {

--- a/users/get.go
+++ b/users/get.go
@@ -9,7 +9,7 @@ import (
 	"path"
 
 	"github.com/oliver-binns/appstore-go/connectapi"
-	"github.com/oliver-binns/googleplay-go/networking"
+	"github.com/oliver-binns/appstore-go/networking"
 )
 
 func Get(c networking.HTTPClient, ctx context.Context, rawURL string, id string) (*User, error) {

--- a/users/modify.go
+++ b/users/modify.go
@@ -10,7 +10,7 @@ import (
 	"path"
 
 	"github.com/oliver-binns/appstore-go/connectapi"
-	"github.com/oliver-binns/googleplay-go/networking"
+	"github.com/oliver-binns/appstore-go/networking"
 )
 
 func Modify(c networking.HTTPClient, ctx context.Context, rawURL string, id string, user User) (*User, error) {


### PR DESCRIPTION
The `googleplay-go` library has been archived. This PR removes the dependency on it by copying the `networking` package directly into this repository.

## Changes
- Add `networking/http_client.go` with `HTTPClient`, `TokenSource` interfaces and `NewAuthorizedClient` constructor
- Add `networking/http_client_test.go` (copied from the archived repo)
- Update all imports across `client.go` and the `users` package to use the local `networking` package
- Remove `github.com/oliver-binns/googleplay-go` from `go.mod`/`go.sum`