### PR TITLE
feat: add FindByEmail to look up users by email address

### DIFF
--- a/client.go
+++ b/client.go
@@ -48,6 +48,10 @@ func (c *Client) ModifyUser(ctx context.Context, id string, user users.User) (*u
 	return users.Modify(*c.client, ctx, c.baseURL, id, user)
 }
 
+func (c *Client) FindUserByEmail(ctx context.Context, email string) (*users.User, error) {
+	return users.FindByEmail(*c.client, ctx, c.baseURL, email)
+}
+
 func (c *Client) DeleteUser(ctx context.Context, id string) error {
 	return users.Delete(*c.client, ctx, c.baseURL, id)
 }

--- a/connectapi/ListResponse.go
+++ b/connectapi/ListResponse.go
@@ -1,0 +1,10 @@
+package connectapi
+
+type ListResponse[T Model, R Relationships] struct {
+	Data  []ResponseData[T, R] `json:"data"`
+	Links ListLinks            `json:"links"`
+}
+
+type ListLinks struct {
+	Next string `json:"next,omitempty"`
+}

--- a/users/find.go
+++ b/users/find.go
@@ -40,17 +40,16 @@ func findActiveUserByEmail(c networking.HTTPClient, ctx context.Context, rawURL 
 	resp, err := c.Do(req)
 	if err != nil {
 		return nil, err
-	} else if resp.StatusCode != http.StatusOK {
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
 	listResponse := new(connectapi.ListResponse[User, *userRelationships])
 	if err := json.NewDecoder(resp.Body).Decode(listResponse); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	if err := resp.Body.Close(); err != nil {
-		return nil, fmt.Errorf("failed to close response body: %w", err)
 	}
 
 	if len(listResponse.Data) == 0 {
@@ -66,7 +65,10 @@ func findActiveUserByEmail(c networking.HTTPClient, ctx context.Context, rawURL 
 }
 
 func findInvitationByEmail(c networking.HTTPClient, ctx context.Context, rawURL string, email string) (*User, error) {
-	parsedURL, _ := url.Parse(rawURL)
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
 	parsedURL.Path = path.Join(parsedURL.Path, "userInvitations")
 
 	query := parsedURL.Query()
@@ -82,17 +84,16 @@ func findInvitationByEmail(c networking.HTTPClient, ctx context.Context, rawURL 
 	resp, err := c.Do(req)
 	if err != nil {
 		return nil, err
-	} else if resp.StatusCode != http.StatusOK {
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
 	listResponse := new(connectapi.ListResponse[userInvitation, *userRelationships])
 	if err := json.NewDecoder(resp.Body).Decode(listResponse); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	if err := resp.Body.Close(); err != nil {
-		return nil, fmt.Errorf("failed to close response body: %w", err)
 	}
 
 	if len(listResponse.Data) == 0 {

--- a/users/find.go
+++ b/users/find.go
@@ -13,6 +13,14 @@ import (
 )
 
 func FindByEmail(c networking.HTTPClient, ctx context.Context, rawURL string, email string) (*User, error) {
+	user, err := findActiveUserByEmail(c, ctx, rawURL, email)
+	if err != nil || user != nil {
+		return user, err
+	}
+	return findInvitationByEmail(c, ctx, rawURL, email)
+}
+
+func findActiveUserByEmail(c networking.HTTPClient, ctx context.Context, rawURL string, email string) (*User, error) {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %w", err)
@@ -55,4 +63,52 @@ func FindByEmail(c networking.HTTPClient, ctx context.Context, rawURL string, em
 	user.HasAcceptedInvite = true
 	user.VisibleAppIDs = userData.Relationships.ids()
 	return &user, nil
+}
+
+func findInvitationByEmail(c networking.HTTPClient, ctx context.Context, rawURL string, email string) (*User, error) {
+	parsedURL, _ := url.Parse(rawURL)
+	parsedURL.Path = path.Join(parsedURL.Path, "userInvitations")
+
+	query := parsedURL.Query()
+	query.Set("filter[email]", email)
+	query.Set("include", "visibleApps")
+	parsedURL.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	} else if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	listResponse := new(connectapi.ListResponse[userInvitation, *userRelationships])
+	if err := json.NewDecoder(resp.Body).Decode(listResponse); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close response body: %w", err)
+	}
+
+	if len(listResponse.Data) == 0 {
+		return nil, nil
+	}
+
+	invData := listResponse.Data[0]
+	return &User{
+		ID:                  invData.ID,
+		FirstName:           invData.Data.FirstName,
+		LastName:            invData.Data.LastName,
+		Username:            invData.Data.Email,
+		Roles:               invData.Data.Roles,
+		AllAppsVisible:      invData.Data.AllAppsVisible,
+		ProvisioningAllowed: invData.Data.ProvisioningAllowed,
+		HasAcceptedInvite:   false,
+		VisibleAppIDs:       invData.Relationships.ids(),
+	}, nil
 }

--- a/users/find.go
+++ b/users/find.go
@@ -41,15 +41,20 @@ func findActiveUserByEmail(c networking.HTTPClient, ctx context.Context, rawURL 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
 	listResponse := new(connectapi.ListResponse[User, *userRelationships])
 	if err := json.NewDecoder(resp.Body).Decode(listResponse); err != nil {
+		_ = resp.Body.Close()
 		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close response body: %w", err)
 	}
 
 	if len(listResponse.Data) == 0 {
@@ -85,15 +90,20 @@ func findInvitationByEmail(c networking.HTTPClient, ctx context.Context, rawURL 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
 	listResponse := new(connectapi.ListResponse[userInvitation, *userRelationships])
 	if err := json.NewDecoder(resp.Body).Decode(listResponse); err != nil {
+		_ = resp.Body.Close()
 		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close response body: %w", err)
 	}
 
 	if len(listResponse.Data) == 0 {

--- a/users/find.go
+++ b/users/find.go
@@ -1,0 +1,58 @@
+package users
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/oliver-binns/appstore-go/connectapi"
+	"github.com/oliver-binns/appstore-go/networking"
+)
+
+func FindByEmail(c networking.HTTPClient, ctx context.Context, rawURL string, email string) (*User, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+	parsedURL.Path = path.Join(parsedURL.Path, "users")
+
+	query := parsedURL.Query()
+	query.Set("filter[username]", email)
+	query.Set("include", "visibleApps")
+	parsedURL.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	} else if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	listResponse := new(connectapi.ListResponse[User, *userRelationships])
+	if err := json.NewDecoder(resp.Body).Decode(listResponse); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close response body: %w", err)
+	}
+
+	if len(listResponse.Data) == 0 {
+		return nil, nil
+	}
+
+	userData := listResponse.Data[0]
+	user := userData.Data
+	user.ID = userData.ID
+	user.HasAcceptedInvite = true
+	user.VisibleAppIDs = userData.Relationships.ids()
+	return &user, nil
+}

--- a/users/find_test.go
+++ b/users/find_test.go
@@ -10,13 +10,20 @@ import (
 )
 
 func TestFindByEmail_MakesRequest(t *testing.T) {
-	httpClient := mocknetworking.MockHTTPClientWith200Response(`{"data": [], "links": {}}`)
+	httpClient := &mocknetworking.MockHTTPClient{
+		Responses: []mocknetworking.MockHTTPResponse{
+			{Body: `{"data": [], "links": {}}`},
+			{Body: `{"data": [], "links": {}}`},
+		},
+	}
 
 	_, _ = FindByEmail(httpClient, context.Background(), "https://example.com", "mail@oliverbinns.co.uk")
 
-	assert.Equal(t, 1, len(httpClient.Requests))
+	assert.Equal(t, 2, len(httpClient.Requests))
 	assert.Equal(t, "GET", httpClient.Requests[0].Method)
 	assert.Equal(t, "https://example.com/users?filter%5Busername%5D=mail%40oliverbinns.co.uk&include=visibleApps", httpClient.Requests[0].URL.String())
+	assert.Equal(t, "GET", httpClient.Requests[1].Method)
+	assert.Equal(t, "https://example.com/userInvitations?filter%5Bemail%5D=mail%40oliverbinns.co.uk&include=visibleApps", httpClient.Requests[1].URL.String())
 }
 
 func TestFindByEmail_ReturnsErrorIfNon200Returned(t *testing.T) {
@@ -29,7 +36,12 @@ func TestFindByEmail_ReturnsErrorIfNon200Returned(t *testing.T) {
 }
 
 func TestFindByEmail_ReturnsNilIfNotFound(t *testing.T) {
-	httpClient := mocknetworking.MockHTTPClientWith200Response(`{"data": [], "links": {}}`)
+	httpClient := &mocknetworking.MockHTTPClient{
+		Responses: []mocknetworking.MockHTTPResponse{
+			{Body: `{"data": [], "links": {}}`},
+			{Body: `{"data": [], "links": {}}`},
+		},
+	}
 
 	user, err := FindByEmail(httpClient, context.Background(), "https://example.com", "notfound@example.com")
 
@@ -70,5 +82,46 @@ func TestFindByEmail_DecodesResponse(t *testing.T) {
 	assert.Equal(t, "Binns", user.LastName)
 	assert.Equal(t, "mail@oliverbinns.co.uk", user.Username)
 	assert.True(t, user.HasAcceptedInvite)
+	assert.Equal(t, []string{"123456"}, user.VisibleAppIDs)
+}
+
+func TestFindByEmail_DecodesInvitationResponse(t *testing.T) {
+	httpClient := &mocknetworking.MockHTTPClient{
+		Responses: []mocknetworking.MockHTTPResponse{
+			{Body: `{"data": [], "links": {}}`},
+			{Body: `{
+				"data": [
+					{
+						"type": "userInvitations",
+						"id": "69a495c9-7dbc-5733-e053-5b8c7c1155b0",
+						"attributes": {
+							"allAppsVisible": true,
+							"lastName": "Binns",
+							"firstName": "Oliver",
+							"provisioningAllowed": true,
+							"roles": ["ACCOUNT_HOLDER", "ADMIN"],
+							"email": "mail@oliverbinns.co.uk"
+						},
+						"relationships": {
+							"visibleApps": {
+								"data": [{"id": "123456", "type": "apps"}]
+							}
+						}
+					}
+				],
+				"links": {}
+			}`},
+		},
+	}
+
+	user, err := FindByEmail(httpClient, context.Background(), "https://example.com", "mail@oliverbinns.co.uk")
+
+	assert.Nil(t, err)
+	assert.NotNil(t, user)
+	assert.Equal(t, "69a495c9-7dbc-5733-e053-5b8c7c1155b0", user.ID)
+	assert.Equal(t, "Oliver", user.FirstName)
+	assert.Equal(t, "Binns", user.LastName)
+	assert.Equal(t, "mail@oliverbinns.co.uk", user.Username)
+	assert.False(t, user.HasAcceptedInvite)
 	assert.Equal(t, []string{"123456"}, user.VisibleAppIDs)
 }

--- a/users/find_test.go
+++ b/users/find_test.go
@@ -1,0 +1,74 @@
+package users
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/oliver-binns/appstore-go/mocknetworking"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindByEmail_MakesRequest(t *testing.T) {
+	httpClient := mocknetworking.MockHTTPClientWith200Response(`{"data": [], "links": {}}`)
+
+	_, _ = FindByEmail(httpClient, context.Background(), "https://example.com", "mail@oliverbinns.co.uk")
+
+	assert.Equal(t, 1, len(httpClient.Requests))
+	assert.Equal(t, "GET", httpClient.Requests[0].Method)
+	assert.Equal(t, "https://example.com/users?filter%5Busername%5D=mail%40oliverbinns.co.uk&include=visibleApps", httpClient.Requests[0].URL.String())
+}
+
+func TestFindByEmail_ReturnsErrorIfNon200Returned(t *testing.T) {
+	httpClient := mocknetworking.MockHTTPClientWithSingleResponse(http.StatusUnauthorized, `{}`)
+
+	user, err := FindByEmail(httpClient, context.Background(), "https://example.com", "mail@oliverbinns.co.uk")
+
+	assert.Nil(t, user)
+	assert.Equal(t, "unexpected status code: 401", err.Error())
+}
+
+func TestFindByEmail_ReturnsNilIfNotFound(t *testing.T) {
+	httpClient := mocknetworking.MockHTTPClientWith200Response(`{"data": [], "links": {}}`)
+
+	user, err := FindByEmail(httpClient, context.Background(), "https://example.com", "notfound@example.com")
+
+	assert.Nil(t, err)
+	assert.Nil(t, user)
+}
+
+func TestFindByEmail_DecodesResponse(t *testing.T) {
+	httpClient := mocknetworking.MockHTTPClientWith200Response(`{
+		"data": [
+			{
+				"type": "users",
+				"id": "69a495c9-7dbc-5733-e053-5b8c7c1155b0",
+				"attributes": {
+					"allAppsVisible": true,
+					"lastName": "Binns",
+					"firstName": "Oliver",
+					"provisioningAllowed": true,
+					"roles": ["ACCOUNT_HOLDER", "ADMIN"],
+					"username": "mail@oliverbinns.co.uk"
+				},
+				"relationships": {
+					"visibleApps": {
+						"data": [{"id": "123456", "type": "apps"}]
+					}
+				}
+			}
+		],
+		"links": {}
+	}`)
+
+	user, err := FindByEmail(httpClient, context.Background(), "https://example.com", "mail@oliverbinns.co.uk")
+
+	assert.Nil(t, err)
+	assert.NotNil(t, user)
+	assert.Equal(t, "69a495c9-7dbc-5733-e053-5b8c7c1155b0", user.ID)
+	assert.Equal(t, "Oliver", user.FirstName)
+	assert.Equal(t, "Binns", user.LastName)
+	assert.Equal(t, "mail@oliverbinns.co.uk", user.Username)
+	assert.True(t, user.HasAcceptedInvite)
+	assert.Equal(t, []string{"123456"}, user.VisibleAppIDs)
+}


### PR DESCRIPTION
## Summary

- Adds `connectapi.ListResponse` — a generic list response type for API endpoints that return collections
- Adds `users.FindByEmail` which looks up a user by email address:
  1. Searches `GET /v1/users?filter[username]=<email>&include=visibleApps` for accepted users
  2. Falls back to `GET /v1/userInvitations?filter[email]=<email>&include=visibleApps` for pending invitations
  3. Returns `nil, nil` if neither endpoint finds a match
- Exposes `FindUserByEmail` on the `Client`

## Motivation

Needed to support email-based import in the Terraform provider ([Oliver-Binns/terraform-provider-appstore#feat/import-by-email](https://github.com/Oliver-Binns/terraform-provider-appstore)). Rather than listing all users and filtering client-side, this uses the server-side filter query parameters so only the matched user is fetched. The invitation fallback is required because newly invited users only appear in `userInvitations` until they accept.

## Test plan

- [x] `TestFindByEmail_MakesRequest` — verifies requests to both `/users` and `/userInvitations` with correct filter parameters
- [x] `TestFindByEmail_ReturnsErrorIfNon200Returned` — verifies error propagation from the users endpoint
- [x] `TestFindByEmail_ReturnsNilIfNotFound` — verifies `nil, nil` when both endpoints return empty lists
- [x] `TestFindByEmail_DecodesResponse` — verifies accepted user: ID, name, username, `HasAcceptedInvite: true`, and `VisibleAppIDs`
- [x] `TestFindByEmail_DecodesInvitationResponse` — verifies pending invitation: same fields, `HasAcceptedInvite: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)