### PR TITLE
fix: check status code in Modify before decoding response

### DIFF
--- a/users/modify.go
+++ b/users/modify.go
@@ -49,6 +49,11 @@ func Modify(c networking.HTTPClient, ctx context.Context, rawURL string, id stri
 		return nil, err
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
 	userResponse := new(connectapi.Response[User, userRelationships])
 	if err := json.NewDecoder(resp.Body).Decode(userResponse); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)

--- a/users/modify_test.go
+++ b/users/modify_test.go
@@ -32,6 +32,26 @@ func TestModifyUser_MakesRequest(t *testing.T) {
 `, bodyString)
 }
 
+func TestModifyUser_ReturnsErrorForNon200Response(t *testing.T) {
+	forbidden := 403
+	httpClient := mocknetworking.MockHTTPClient{
+		Responses: []mocknetworking.MockHTTPResponse{
+			{
+				StatusCode: &forbidden,
+				Body:       `{"errors": [{"status": "403", "title": "Forbidden"}]}`,
+			},
+		},
+	}
+
+	user, err := Modify(
+		&httpClient, context.Background(), "https://example.com", "dummy-id",
+		User{},
+	)
+
+	assert.Nil(t, user)
+	assert.ErrorContains(t, err, "403")
+}
+
 func TestModifyUser_DecodesResponse(t *testing.T) {
 	httpClient := mocknetworking.MockHTTPClientWith200Response(`
 	{


### PR DESCRIPTION
## Summary

- `Modify` was not checking the HTTP status code before attempting to decode the response body.
- A non-200 response (e.g. 403 Forbidden) would be decoded into a zero-value `User` struct without returning an error, causing callers to silently receive empty user data.

## Test plan

- [x] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)