### PR TITLE
fix: return error when Get is called with an empty user ID

### DIFF
--- a/users/get.go
+++ b/users/get.go
@@ -13,6 +13,10 @@ import (
 )
 
 func Get(c networking.HTTPClient, ctx context.Context, rawURL string, id string) (*User, error) {
+	if id == "" {
+		return nil, fmt.Errorf("user ID cannot be empty")
+	}
+
 	// Parse the raw URL
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {

--- a/users/get_test.go
+++ b/users/get_test.go
@@ -9,6 +9,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestGetUser_ReturnsErrorForEmptyID(t *testing.T) {
+	httpClient := mocknetworking.MockHTTPClientWith200Response(`{ }`)
+
+	_, err := Get(
+		httpClient, context.Background(), "https://example.com", "",
+	)
+
+	assert.ErrorContains(t, err, "user ID cannot be empty")
+	assert.Equal(t, len(httpClient.Requests), 0)
+}
+
 func TestGetUser_MakesRequest(t *testing.T) {
 	httpClient := mocknetworking.MockHTTPClientWith200Response(`{ }`)
 


### PR DESCRIPTION
## Summary

- Adds an early guard in `Get()` that returns a clear error when called with an empty ID
- Without this guard, an empty ID causes the request to go to `GET /v1/users` (the list endpoint) instead of `GET /v1/users/{id}`, resulting in a confusing JSON unmarshal error: `cannot unmarshal array into Go struct field Response.data`

## Test plan

- [ ] `TestGetUser_ReturnsErrorForEmptyID` — verifies no HTTP request is made and a clear error is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)