### PR TITLE
fix: return error when Modify is called with empty user ID

### DIFF
--- a/users/modify.go
+++ b/users/modify.go
@@ -14,6 +14,10 @@ import (
 )
 
 func Modify(c networking.HTTPClient, ctx context.Context, rawURL string, id string, user User) (*User, error) {
+	if id == "" {
+		return nil, fmt.Errorf("user ID cannot be empty")
+	}
+
 	// Parse the raw URL
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {

--- a/users/modify_test.go
+++ b/users/modify_test.go
@@ -32,6 +32,19 @@ func TestModifyUser_MakesRequest(t *testing.T) {
 `, bodyString)
 }
 
+func TestModifyUser_ReturnsErrorForEmptyID(t *testing.T) {
+	httpClient := mocknetworking.MockHTTPClientWith200Response(`{}`)
+
+	user, err := Modify(
+		httpClient, context.Background(), "https://example.com", "",
+		User{},
+	)
+
+	assert.Nil(t, user)
+	assert.ErrorContains(t, err, "user ID cannot be empty")
+	assert.Equal(t, 0, len(httpClient.Requests))
+}
+
 func TestModifyUser_ReturnsErrorForNon200Response(t *testing.T) {
 	forbidden := 403
 	httpClient := mocknetworking.MockHTTPClient{


### PR DESCRIPTION
Adds a guard at the top of `Modify` mirroring the existing check in `Get`. Prevents a malformed PATCH request to `/v1/users/` (no ID) which the App Store Connect API rejects with 405.